### PR TITLE
fix javadoc (invalid imports)

### DIFF
--- a/wro4j-core/src/main/java/ro/isdc/wro/model/resource/processor/SupportedResourceTypeAware.java
+++ b/wro4j-core/src/main/java/ro/isdc/wro/model/resource/processor/SupportedResourceTypeAware.java
@@ -4,8 +4,6 @@
  */
 package ro.isdc.wro.model.resource.processor;
 
-import javax.annotation.processing.SupportedAnnotationTypes;
-
 import ro.isdc.wro.model.resource.ResourceType;
 import ro.isdc.wro.model.resource.SupportedResourceType;
 
@@ -13,7 +11,7 @@ import ro.isdc.wro.model.resource.SupportedResourceType;
 /**
  * Mark processor implementing this interface that they are capable of providing supported {@link ResourceType}. This is
  * useful for Resource processor decorators, which should "inherit" the decorated resources
- * {@link SupportedAnnotationTypes}. This interface was created as a workaround, because you cannot set annotations at
+ * {@link SupportedResourceType}. This interface was created as a workaround, because you cannot set annotations at
  * runtime in java.
  *
  * @author Alex Objelean

--- a/wro4j-core/src/main/java/ro/isdc/wro/util/WroTestUtils.java
+++ b/wro4j-core/src/main/java/ro/isdc/wro/util/WroTestUtils.java
@@ -17,8 +17,6 @@ import java.io.Writer;
 import java.util.Collection;
 import java.util.Properties;
 
-import javax.annotation.processing.Processor;
-
 import junit.framework.Assert;
 import junit.framework.ComparisonFailure;
 
@@ -382,7 +380,7 @@ public class WroTestUtils {
    * @param targetFolder folder where the target files are located.
    * @param fileFilter filter used to select files to process.
    * @param toTargetFileName {@link Transformer} used to identify the target file name based on source file name.
-   * @param preProcessor {@link Processor} used to process the source files.
+   * @param preProcessor {@link ResourcePreProcessor} used to process the source files.
    * @throws IOException
    */
   public static void compareFromDifferentFolders(final File sourceFolder, final File targetFolder,


### PR DESCRIPTION
Eclipse complains because they're referring to classes that aren't available in Java 5.
