### PR TITLE
Adjusted javadoc to reflect the actual HashBuilder implementation used 

### DIFF
--- a/wro4j-core/src/main/java/ro/isdc/wro/model/resource/util/HashEncoderNamingStrategy.java
+++ b/wro4j-core/src/main/java/ro/isdc/wro/model/resource/util/HashEncoderNamingStrategy.java
@@ -13,7 +13,7 @@ import org.apache.commons.lang3.StringUtils;
 /**
  * The simplest implementation of {@link NamingStrategy} which encodes the hash code into the name of the
  * resource. For instance: For <code>group.js</code> -> <code>group-<hashcode>.js</code>. This implementation uses by
- * default {@link MD5HashBuilder} implementation.
+ * default {@link CRC32HashBuilder} implementation.
  *
  * @author Alex Objelean
  * @created 15 Aug 2010


### PR DESCRIPTION
Adjusted javadoc to reflect the actual `HashBuilder` implementation used by default
