### PR TITLE
Issue 13 - Use Group's name as Resource's uri for the resource passed to post processors.

### DIFF
--- a/wro4j-core/src/main/java/ro/isdc/wro/manager/ReloadCacheRunnable.java
+++ b/wro4j-core/src/main/java/ro/isdc/wro/manager/ReloadCacheRunnable.java
@@ -48,8 +48,6 @@ public final class ReloadCacheRunnable
       for (final Group group : groups) {
         for (final ResourceType resourceType : ResourceType.values()) {
           if (group.hasResourcesOfType(resourceType)) {
-            final Collection<Group> groupAsList = new HashSet<Group>();
-            groupAsList.add(group);
             // TODO check if request parameter can be fetched here without errors.
             // groupExtractor.isMinimized(Context.get().getRequest())
             final Boolean[] minimizeValues = new Boolean[] { true, false };
@@ -59,7 +57,7 @@ public final class ReloadCacheRunnable
                 LOG.debug("ReloadCacheRunnable was interrupted - stop processing!");
                 throw new InterruptedException();
               }
-              final String content = wroManagerReference.get().getGroupsProcessor().process(groupAsList, resourceType,
+              final String content = wroManagerReference.get().getGroupsProcessor().process(group, resourceType,
                 minimize);
               final CacheEntry cacheEntry = new CacheEntry(group.getName(), resourceType, minimize);
               final ContentHashEntry contentHashEntry = wroManagerReference.get().getContentHashEntryByContent(content);

--- a/wro4j-core/src/main/java/ro/isdc/wro/manager/WroManager.java
+++ b/wro4j-core/src/main/java/ro/isdc/wro/manager/WroManager.java
@@ -279,15 +279,14 @@ public class WroManager
       LOG.debug("Cache is empty. Perform processing...");
       // process groups & put result in the cache
       // find processed result for a group
-      final List<Group> groupAsList = new ArrayList<Group>();
+      
       final WroModel model = modelFactory.create();
       if (model == null) {
         throw new WroRuntimeException("Cannot build a valid wro model");
       }
       final Group group = model.getGroupByName(groupName);
-      groupAsList.add(group);
 
-      final String content = groupsProcessor.process(groupAsList, type, minimize);
+      final String content = groupsProcessor.process(group, type, minimize);
       contentHashEntry = getContentHashEntryByContent(content);
       if (!Context.get().getConfig().isDisableCache()) {
         cacheStrategy.put(cacheEntry, contentHashEntry);

--- a/wro4j-core/src/main/java/ro/isdc/wro/model/group/processor/PreProcessorExecutor.java
+++ b/wro4j-core/src/main/java/ro/isdc/wro/model/group/processor/PreProcessorExecutor.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 import ro.isdc.wro.WroRuntimeException;
 import ro.isdc.wro.config.Context;
 import ro.isdc.wro.config.jmx.WroConfiguration;
+import ro.isdc.wro.model.group.Group;
 import ro.isdc.wro.model.group.Inject;
 import ro.isdc.wro.model.resource.Resource;
 import ro.isdc.wro.model.resource.locator.factory.ResourceLocatorFactory;
@@ -51,15 +52,17 @@ public final class PreProcessorExecutor {
   /**
    * Apply preProcessors on resources and merge them.
    *
-   * @param resources what are the resources to merge.
+   * @param group what are the resources to merge.
    * @param minimize whether minimize aware processors must be applied or not.
    * @return preProcessed merged content.
    * @throws IOException if IO error occurs while merging.
    */
-  public String processAndMerge(final List<Resource> resources, final boolean minimize)
+  public String processAndMerge(final Group group, final boolean minimize)
     throws IOException {
-    Validate.notNull(resources);
+    Validate.notNull(group);
 
+    final List<Resource> resources = group.getResources();
+    
     final StringBuffer result = new StringBuffer();
 
     final boolean isParallel = Context.get().getConfig().isParallelPreprocessing();

--- a/wro4j-core/src/main/java/ro/isdc/wro/model/resource/processor/impl/css/CssImportPreProcessor.java
+++ b/wro4j-core/src/main/java/ro/isdc/wro/model/resource/processor/impl/css/CssImportPreProcessor.java
@@ -18,6 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import ro.isdc.wro.config.Context;
+import ro.isdc.wro.model.group.Group;
 import ro.isdc.wro.model.group.Inject;
 import ro.isdc.wro.model.group.processor.PreProcessorExecutor;
 import ro.isdc.wro.model.resource.Resource;
@@ -90,7 +91,9 @@ public class CssImportPreProcessor
     // for now, minimize always
     // TODO: find a way to get minimize property dynamically.
     //groupExtractor.isMinimized(Context.get().getRequest())
-    sb.append(preProcessorExecutor.processAndMerge(importsCollector, true));
+    Group group = new Group("dummy");
+    group.setResources(importsCollector);
+    sb.append(preProcessorExecutor.processAndMerge(group, true));
     if (!importsCollector.isEmpty()) {
       LOG.debug("Imported resources found : {}", importsCollector.size());
     }


### PR DESCRIPTION
Hi Alex,

Here is what I did.
All tests in -core pass (after updating some of them to the new APIs).
I didn't test it with our application because we use 1.4.1 at the moment.
