### PR TITLE
add a timestamp naming strategy. 

### DIFF
--- a/wro4j-core/src/main/java/ro/isdc/wro/model/resource/util/TimestampNamingStrategy.java
+++ b/wro4j-core/src/main/java/ro/isdc/wro/model/resource/util/TimestampNamingStrategy.java
@@ -1,0 +1,50 @@
+/*
+* Copyright 2011 France Télécom
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package ro.isdc.wro.model.resource.util;
+
+import java.io.InputStream;
+
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * This naming strategy append a timestamp to the name of the file.
+ * 
+ * This is especially useful when wro4j is used at build time with the
+ * maven plugin.
+ * 
+ * @author Julien Wajsberg
+ */
+public class TimestampNamingStrategy implements NamingStrategy {
+
+	public String rename(String originalName, InputStream inputStream) {
+	    final String baseName = FilenameUtils.getBaseName(originalName);
+	    final String extension = FilenameUtils.getExtension(originalName);
+	    final long timestamp = getTimestamp();
+	    final StringBuilder sb = new StringBuilder(baseName).append("-").append(timestamp);
+	    if (!StringUtils.isEmpty(extension)) {
+	      sb.append(".").append(extension);
+	    }
+	    return sb.toString();
+	}
+	
+	/* protected to make the class testable. Should we ? */
+	protected long getTimestamp() {
+		return System.currentTimeMillis();
+	}
+	
+}

--- a/wro4j-core/src/test/java/ro/isdc/wro/model/resource/util/TestTimestampNamingStrategy.java
+++ b/wro4j-core/src/test/java/ro/isdc/wro/model/resource/util/TestTimestampNamingStrategy.java
@@ -1,0 +1,63 @@
+/*
+* Copyright 2011 France Télécom
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+* 
+* This was inspired by TestFingerprintCreatorNamingStrategy.
+*/
+
+package ro.isdc.wro.model.resource.util;
+
+import static junit.framework.Assert.*;
+
+
+import org.junit.Before;
+import org.junit.Test;
+
+import ro.isdc.wro.model.resource.util.NamingStrategy;
+
+/**
+ * Test class for {@link TimestampNamingStrategy}
+ *
+ * @author Julien Wajsberg
+ * @created 05 dec 2011
+ */
+public class TestTimestampNamingStrategy {
+  private NamingStrategy namingStrategy;
+
+  private static long TIMESTAMP = 123456789;
+  
+  @Before
+  public void setUp() {
+    namingStrategy = new TimestampNamingStrategy() {
+    	@Override
+    	protected long getTimestamp() {
+    		return TIMESTAMP;
+    	}
+    };
+  }
+
+  @Test
+  public void testWithExtension() throws Exception {
+    //second argument doesn't matter.
+    final String result = namingStrategy.rename("fileName.js", null);
+    assertEquals("fileName-" + TIMESTAMP + ".js", result);
+  }
+
+  @Test
+  public void testNoExtension() throws Exception {
+  //second argument doesn't matter.
+    final String result = namingStrategy.rename("fileName", null);
+    assertEquals("fileName-" + TIMESTAMP, result);
+  }
+}


### PR DESCRIPTION
This is especially useful pour buildtime uses of wro4j, as this is faster than the HashEncoderNamingStrategy, but it is quite useless if wro4j is used at runtime.

I added it in wro4j-core, tell me if it's not correct. Also I'm not sure of the correct branch...
