### PR TITLE
Fix for issue in not correctly writing UTF-8 formatted data

### DIFF
--- a/wro4j-core/src/main/java/ro/isdc/wro/cache/ContentHashEntry.java
+++ b/wro4j-core/src/main/java/ro/isdc/wro/cache/ContentHashEntry.java
@@ -46,7 +46,7 @@ public final class ContentHashEntry
     try {
       final ByteArrayOutputStream baos = new ByteArrayOutputStream();
       final OutputStream os = new GZIPOutputStream(new BufferedOutputStream(baos));
-      IOUtils.copy(new ByteArrayInputStream(content.getBytes()), os);
+      IOUtils.copy(new ByteArrayInputStream(content.getBytes(Context.get().getConfig().getEncoding())), os);
       os.close();
       return baos.toByteArray();
     } catch (final IOException e) {

--- a/wro4j-core/src/main/java/ro/isdc/wro/manager/WroManager.java
+++ b/wro4j-core/src/main/java/ro/isdc/wro/manager/WroManager.java
@@ -204,7 +204,7 @@ public class WroManager
           response.setHeader("Vary", "Accept-Encoding");
           IOUtils.write(contentHashEntry.getGzippedContent(), os);
         } else {
-          IOUtils.write(contentHashEntry.getRawContent(), os);
+          IOUtils.write(contentHashEntry.getRawContent(), os, Context.get().getConfig().getEncoding());
         }
       }
 


### PR DESCRIPTION
HI Alex,

This is a fix for issue 253 in the encoding of https://github.com/yui/yui3/blob/v3.4.1/src/text/js/text-data-wordbreak.js

Works fine in 1.3.x but in 1.4.x there are multiple places where the rawContent (String) is being written to a ByteArrayOutputStream without specifying the encoding.  This commit should fix those (and fixes issue 253 for us).

Thanks,
Garrett
