### PR TITLE
Solves issue-385 - Order of dispatherStreamLocator and servletStreamLocator.

### DIFF
--- a/wro4j-core/src/test/java/ro/isdc/wro/model/resource/locator/TestServletContextUriLocator.java
+++ b/wro4j-core/src/test/java/ro/isdc/wro/model/resource/locator/TestServletContextUriLocator.java
@@ -3,8 +3,7 @@
  */
 package ro.isdc.wro.model.resource.locator;
 
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.net.URL;
 
 import javax.servlet.RequestDispatcher;
@@ -121,6 +120,20 @@ public class TestServletContextUriLocator {
     Mockito.when(Context.get().getServletContext().getResourceAsStream(Mockito.anyString())).thenReturn(null);
     Mockito.when(Context.get().getServletContext().getRequestDispatcher(Mockito.anyString())).thenReturn(null);
     simulateRedirectWithLocation("http://INVALID/");
+  }
+    
+  @Test
+  public void shouldPreferServletContextBasedResolving() throws IOException {
+    InputStream is = new ByteArrayInputStream("a {}".getBytes());
+    Mockito.when(Context.get().getServletContext().getResourceAsStream(Mockito.anyString())).thenReturn(is);
+
+    ServletContextUriLocator locator = new ServletContextUriLocator();
+    locator.setUseDispatcherBasedLocatorFirst(false);
+
+    InputStream actualIs = locator.locate("test.css");
+
+    BufferedReader br = new BufferedReader(new InputStreamReader(actualIs));
+    Assert.assertEquals("a {}", br.readLine());
   }
 
 


### PR DESCRIPTION
Intial attempt to solve issue http://code.google.com/p/wro4j/issues/detail?id=385 allowing the user of ServletContextUriLocator to determine the streamLocator to try first. 

Available streamLocators:
- dispatcher - allows for dynamic resources to be included.
- servletContext - only includes static files found direcly in the webapp folder

Default behaviour is to first try using the dispatcherStreamLocator first. If the user specifies the constructor arg (useDispatcherBasedLocatorFirst) he can choose to use the servletContextStreamLocator first:

new ServletContextUriLocator(false);
