### PR TITLE
WildcardExpanderModelTransformer problem with /** url

### DIFF
--- a/wro4j-core/src/main/java/ro/isdc/wro/model/transformer/WildcardExpanderModelTransformer.java
+++ b/wro4j-core/src/main/java/ro/isdc/wro/model/transformer/WildcardExpanderModelTransformer.java
@@ -188,7 +188,7 @@ public class WildcardExpanderModelTransformer
           final List<Resource> expandedResources = new ArrayList<Resource>();
           LOG.debug("baseNameFolder: {}", baseNameFolder);
           for (final File file : files) {
-            final String resourcePath = FilenameUtils.getFullPathNoEndSeparator(resource.getUri());
+            final String resourcePath = getFullPathNoEndSeparator(resource);
             LOG.debug("\tresourcePath: {}", resourcePath);
             LOG.debug("\tfile path: {}", file.getPath());
             final String computedResourceUri = resourcePath
@@ -203,6 +203,14 @@ public class WildcardExpanderModelTransformer
         }
         return null;
       }
+
+	private String getFullPathNoEndSeparator(final Resource resource) {
+		String result = FilenameUtils.getFullPathNoEndSeparator(resource.getUri());
+		if (result!=null && 1==result.length() && 0==FilenameUtils.indexOfLastSeparator(result))
+			return "";
+		
+		return result;
+	}
     };
     return handler;
   }


### PR DESCRIPTION
If the resource in a group uses deep wilcard and starts at the root, then the WildcardExpanderModelTransformer can not find referenced resources.

Example: The following group:
<group name="main_style">
  <css>/**.css</css>
  <js>/**.js</js>
</group>

would be empty.

More details: If the "ie.css" file is located in "resources/" directory, preprocessor executor looks for "//resources/ie.css" which does not exists. It should look for "/resources/ie.css" instead.

The problem is in the createExpanderHandler method of WildcardExpanderModelTransformer. It uses FilenameUtils.getFullPathNoEndSeparator to get the resource path without the last slash. This method is unwilling to return an empty string. E.g.:
- FilenameUtils.getFullPathNoEndSeparator("/resources/**.css") returns "/resources
- FilenameUtils.getFullPathNoEndSeparator("/**.css") returns "/"

Note: Following group works correcty:
<group name="main_style">
  <css>/resources/**.css</css>
  <js>/resources/**.js</js>
</group>
