### PR TITLE
Fixed Dispatcher-based resource location when running with JRebel

### DIFF
--- a/wro4j-core/src/main/java/ro/isdc/wro/model/resource/locator/DispatcherStreamLocator.java
+++ b/wro4j-core/src/main/java/ro/isdc/wro/model/resource/locator/DispatcherStreamLocator.java
@@ -114,13 +114,13 @@ public final class DispatcherStreamLocator {
 
       @Override
       public String getPathInfo() {
-        return WroUtil.getPathInfoFromLocation(location);
+        return WroUtil.getPathInfoFromLocation(this, location);
       }
 
 
       @Override
       public String getServletPath() {
-        return WroUtil.getServletPathFromLocation(location);
+        return WroUtil.getServletPathFromLocation(this, location);
       }
     };
     return wrappedRequest;

--- a/wro4j-core/src/main/java/ro/isdc/wro/util/WroUtil.java
+++ b/wro4j-core/src/main/java/ro/isdc/wro/util/WroUtil.java
@@ -88,12 +88,22 @@ public final class WroUtil {
   /**
    * Retrieve pathInfo from a given location.
    *
+   *
+   * @param request
    * @param location where to search contextPath.
    * @return pathInfo value.
    */
-  public static String getPathInfoFromLocation(final String location) {
+  public static String getPathInfoFromLocation(final HttpServletRequest request, final String location) {
     if (StringUtils.isEmpty(location)) {
       throw new IllegalArgumentException("Location cannot be empty string!");
+    }
+    final String contextPath = request.getContextPath();
+    if (contextPath != null) {
+      if (startsWithIgnoreCase(location, contextPath)) {
+        return location.substring(contextPath.length());
+      } else {
+        return location;
+      }
     }
     final String noSlash = location.substring(1);
     final int nextSlash = noSlash.indexOf('/');
@@ -171,8 +181,8 @@ public final class WroUtil {
    * @param location where to search the servletPath.
    * @return ServletPath string value.
    */
-  public static String getServletPathFromLocation(final String location) {
-    return location.replace(getPathInfoFromLocation(location), "");
+  public static String getServletPathFromLocation(final HttpServletRequest request, final String location) {
+    return location.replace(getPathInfoFromLocation(request, location), "");
   }
 
   /**

--- a/wro4j-core/src/test/java/ro/isdc/wro/util/TestWroUtil.java
+++ b/wro4j-core/src/test/java/ro/isdc/wro/util/TestWroUtil.java
@@ -23,27 +23,39 @@ import org.mockito.Mockito;
 public class TestWroUtil {
   @Test(expected = IllegalArgumentException.class)
   public void cannotComputeEmptyLocation() {
-    WroUtil.getPathInfoFromLocation("");
+    WroUtil.getPathInfoFromLocation(mockContextPathRequest(null), "");
   }
   
   @Test
   public void computePathFromSomeLocation() {
-    final String result = WroUtil.getPathInfoFromLocation("location");
+    final String result = WroUtil.getPathInfoFromLocation(mockContextPathRequest(null), "location");
     Assert.assertEquals("", result);
   }
   
   @Test
   public void computePathFromNestedLocation() {
-    final String result = WroUtil.getPathInfoFromLocation("/a/b/c/d");
+    final String result = WroUtil.getPathInfoFromLocation(mockContextPathRequest(null), "/a/b/c/d");
     Assert.assertEquals("/b/c/d", result);
   }
-  
+
+  @Test
+  public void computePathFromLocationWithContextRoot() {
+    final String result = WroUtil.getPathInfoFromLocation(mockContextPathRequest("/a"), "/a/b/c/d");
+    Assert.assertEquals("/b/c/d", result);
+  }
+
+  @Test
+  public void computePathFromLocationWithDifferentContextRoot() {
+    final String result = WroUtil.getPathInfoFromLocation(mockContextPathRequest("/z"), "/a/b/c/d");
+    Assert.assertEquals("/a/b/c/d", result);
+  }
+
   @Test
   public void computeServletPathFromLocation() {
-    final String result = WroUtil.getServletPathFromLocation("/a/b/c/d");
+    final String result = WroUtil.getServletPathFromLocation(mockContextPathRequest(null), "/a/b/c/d");
     Assert.assertEquals("/a", result);
   }
-  
+
   /**
    * Test for several mangled header examples based on {@link http
    * ://developer.yahoo.com/blogs/ydn/posts/2010/12/pushing-beyond-gzipping/} blog post.
@@ -97,7 +109,13 @@ public class TestWroUtil {
     Mockito.when(request.getHeader(headerName)).thenReturn(headerValue);
     return request;
   }
-  
+
+  private HttpServletRequest mockContextPathRequest(final String contextPath) {
+    final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+    Mockito.when(request.getContextPath()).thenReturn(contextPath);
+    return request;
+  }
+
   @Test
   public void testToJsMultilineString() {
     Assert.assertEquals("[\"\\n\"].join(\"\\n\")", WroUtil.toJSMultiLineString(""));


### PR DESCRIPTION
This patch fixes the resource location issue reported at https://groups.google.com/d/topic/wro4j/SFzEwhnvuM8/discussion
