### PR TITLE
Issue 480: Css url rewriting doesn't compute replace properly font rule with multiple url's

### DIFF
--- a/wro4j-core/src/main/java/ro/isdc/wro/model/resource/processor/impl/css/CssImportPreProcessor.java
+++ b/wro4j-core/src/main/java/ro/isdc/wro/model/resource/processor/impl/css/CssImportPreProcessor.java
@@ -3,13 +3,8 @@
  */
 package ro.isdc.wro.model.resource.processor.impl.css;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.regex.Matcher;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import ro.isdc.wro.config.jmx.WroConfiguration;
 import ro.isdc.wro.model.group.Inject;
 import ro.isdc.wro.model.group.processor.PreProcessorExecutor;
@@ -18,6 +13,10 @@ import ro.isdc.wro.model.resource.ResourceType;
 import ro.isdc.wro.model.resource.SupportedResourceType;
 import ro.isdc.wro.model.resource.processor.support.ProcessingCriteria;
 import ro.isdc.wro.model.resource.processor.support.ProcessingType;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.regex.Matcher;
 
 
 /**
@@ -45,7 +44,7 @@ public class CssImportPreProcessor
   @Override
   protected String doTransform(final String cssContent, final List<Resource> foundImports)
       throws IOException {
-    final StringBuffer sb = new StringBuffer();
+    final StringBuilder sb = new StringBuilder();
     // for now, minimize always
     // TODO: find a way to get minimize property dynamically.
     sb.append(preProcessorExecutor.processAndMerge(foundImports,

--- a/wro4j-core/src/main/java/ro/isdc/wro/model/resource/processor/impl/css/FallbackCssDataUriProcessor.java
+++ b/wro4j-core/src/main/java/ro/isdc/wro/model/resource/processor/impl/css/FallbackCssDataUriProcessor.java
@@ -46,7 +46,7 @@ public class FallbackCssDataUriProcessor
     return originalDeclaration.equals(modifiedDeclaration) ? modifiedDeclaration : computeNewDeclaration(
         originalDeclaration, modifiedDeclaration);
   }
-  
+
   /**
    * @return the new declaration which contains both: old and new modified declarations.
    */
@@ -54,7 +54,27 @@ public class FallbackCssDataUriProcessor
     LOG.debug("originalDeclaration: {}", originalDeclaration);
     LOG.debug("modifiedDeclaration: {}", modifiedDeclaration);
     // helps to avoid duplicate unnecessary separator
-    final String separator = originalDeclaration.trim().endsWith(SEPARATOR) ? StringUtils.EMPTY : SEPARATOR;
+    String separator = originalDeclaration.trim().endsWith(SEPARATOR) ? StringUtils.EMPTY : SEPARATOR;
     return originalDeclaration + separator + modifiedDeclaration;
   }
+
+    @Override
+    protected String getRegexPatternKey() {
+        return "cssUrlRewrite.fallbackCssDataUriProcessor";
+    }
+
+    @Override
+    public int getDeclarationIndex() {
+        return 1;
+    }
+
+    @Override
+    protected int getUrlIndexA() {
+        return 2;
+    }
+
+    @Override
+    protected int getUrlIndexB() {
+        return 3;
+    }
 }

--- a/wro4j-core/src/main/resources/ro/isdc/wro/util/regexp.properties
+++ b/wro4j-core/src/main/resources/ro/isdc/wro/util/regexp.properties
@@ -1,5 +1,6 @@
 # The pattern used to detect url's inside css
-cssUrlRewrite=(?is)([\w-]*\s*?:[^{]*?\b(?:src\b\s*=\s*['"](.*?)['"].*?|url\b\s*\(\s*['"]?(.*?)['"]?\s*\)).*?)(?=(?:[\s|\r|\n]*?[\w-]*\s*:|}))
+cssUrlRewrite.fallbackCssDataUriProcessor=(?is)([\w-]*\s*?:[^{]*?\b(?:src\b\s*=\s*['"](.*?)['"].*?|url\b\s*\(\s*['"]?(.*?)['"]?\s*\)).*?)(?=(?:[\s|\r|\n]*?[\w-]*\s*:|}))
+cssUrlRewrite=(?is)src\b\s*=\s*['"](.*?)['"]|url\b\s*\(\s*['"]?(.*?)['"]?\s*\)
 
 # Identifies @import url's inside css files
 cssImport=(?i)@import\s*(?:url\()?[\"']?([^\"')]+)[\"')]?\)?;?

--- a/wro4j-core/src/test/resources/cssUrlRewriting-WEBINFservletContext-outcome.css
+++ b/wro4j-core/src/test/resources/cssUrlRewriting-WEBINFservletContext-outcome.css
@@ -81,3 +81,13 @@
 .specialCharacters {
     background-image: url( [WRO-PREFIX]?id=/WEB-INF/path/with/$pecial/character.png);
 }
+@font-face {
+    font-family: 'Trade Gothic Condensed Bold';
+    src: url('[WRO-PREFIX]?id=/WEB-INF/fonts/tradegothic-boldcondtwenty-webfont.eot');
+    src: url('[WRO-PREFIX]?id=/WEB-INF/fonts/tradegothic-boldcondtwenty-webfont.eot?#iefix') format('embedded-opentype'),
+    url('[WRO-PREFIX]?id=/WEB-INF/fonts/tradegothic-boldcondtwenty-webfont.woff') format('woff'),
+    url('[WRO-PREFIX]?id=/WEB-INF/fonts/tradegothic-boldcondtwenty-webfont.ttf') format('truetype'),
+    url('[WRO-PREFIX]?id=/WEB-INF/fonts/tradegothic-boldcondtwenty-webfont.svg#tradegothic-boldcondtwenty-webfont') format('svg');
+    font-weight: normal;
+    font-style: normal;
+}

--- a/wro4j-core/src/test/resources/cssUrlRewriting-classpath-outcome.css
+++ b/wro4j-core/src/test/resources/cssUrlRewriting-classpath-outcome.css
@@ -81,3 +81,13 @@
 .specialCharacters {
     background-image: url( [WRO-PREFIX]?id=classpath:path/with/$pecial/character.png);
 }
+@font-face {
+    font-family: 'Trade Gothic Condensed Bold';
+    src: url('[WRO-PREFIX]?id=classpath:fonts/tradegothic-boldcondtwenty-webfont.eot');
+    src: url('[WRO-PREFIX]?id=classpath:fonts/tradegothic-boldcondtwenty-webfont.eot?#iefix') format('embedded-opentype'),
+    url('[WRO-PREFIX]?id=classpath:fonts/tradegothic-boldcondtwenty-webfont.woff') format('woff'),
+    url('[WRO-PREFIX]?id=classpath:fonts/tradegothic-boldcondtwenty-webfont.ttf') format('truetype'),
+    url('[WRO-PREFIX]?id=classpath:fonts/tradegothic-boldcondtwenty-webfont.svg#tradegothic-boldcondtwenty-webfont') format('svg');
+    font-weight: normal;
+    font-style: normal;
+}

--- a/wro4j-core/src/test/resources/cssUrlRewriting-servletContext-aggregatedFolderSet-outcome.css
+++ b/wro4j-core/src/test/resources/cssUrlRewriting-servletContext-aggregatedFolderSet-outcome.css
@@ -81,3 +81,13 @@
 .specialCharacters {
     background-image: url( ../../static/img/path/with/$pecial/character.png);
 }
+@font-face {
+    font-family: 'Trade Gothic Condensed Bold';
+    src: url('../../static/img/fonts/tradegothic-boldcondtwenty-webfont.eot');
+    src: url('../../static/img/fonts/tradegothic-boldcondtwenty-webfont.eot?#iefix') format('embedded-opentype'),
+    url('../../static/img/fonts/tradegothic-boldcondtwenty-webfont.woff') format('woff'),
+    url('../../static/img/fonts/tradegothic-boldcondtwenty-webfont.ttf') format('truetype'),
+    url('../../static/img/fonts/tradegothic-boldcondtwenty-webfont.svg#tradegothic-boldcondtwenty-webfont') format('svg');
+    font-weight: normal;
+    font-style: normal;
+}

--- a/wro4j-core/src/test/resources/cssUrlRewriting-servletContext-outcome.css
+++ b/wro4j-core/src/test/resources/cssUrlRewriting-servletContext-outcome.css
@@ -81,3 +81,13 @@
 .specialCharacters {
     background-image: url( /static/img/path/with/$pecial/character.png);
 }
+@font-face {
+    font-family: 'Trade Gothic Condensed Bold';
+    src: url('/static/img/fonts/tradegothic-boldcondtwenty-webfont.eot');
+    src: url('/static/img/fonts/tradegothic-boldcondtwenty-webfont.eot?#iefix') format('embedded-opentype'),
+    url('/static/img/fonts/tradegothic-boldcondtwenty-webfont.woff') format('woff'),
+    url('/static/img/fonts/tradegothic-boldcondtwenty-webfont.ttf') format('truetype'),
+    url('/static/img/fonts/tradegothic-boldcondtwenty-webfont.svg#tradegothic-boldcondtwenty-webfont') format('svg');
+    font-weight: normal;
+    font-style: normal;
+}

--- a/wro4j-core/src/test/resources/cssUrlRewriting-url-outcome.css
+++ b/wro4j-core/src/test/resources/cssUrlRewriting-url-outcome.css
@@ -81,3 +81,13 @@
 .specialCharacters {
     background-image: url( http://www.site.com/static/css/path/with/$pecial/character.png);
 }
+@font-face {
+    font-family: 'Trade Gothic Condensed Bold';
+    src: url('http://www.site.com/static/css/fonts/tradegothic-boldcondtwenty-webfont.eot');
+    src: url('http://www.site.com/static/css/fonts/tradegothic-boldcondtwenty-webfont.eot?#iefix') format('embedded-opentype'),
+    url('http://www.site.com/static/css/fonts/tradegothic-boldcondtwenty-webfont.woff') format('woff'),
+    url('http://www.site.com/static/css/fonts/tradegothic-boldcondtwenty-webfont.ttf') format('truetype'),
+    url('http://www.site.com/static/css/fonts/tradegothic-boldcondtwenty-webfont.svg#tradegothic-boldcondtwenty-webfont') format('svg');
+    font-weight: normal;
+    font-style: normal;
+}

--- a/wro4j-core/src/test/resources/cssUrlRewriting.css
+++ b/wro4j-core/src/test/resources/cssUrlRewriting.css
@@ -82,3 +82,13 @@
 .specialCharacters {
     background-image: url( path/with/$pecial/character.png);
 }
+@font-face {
+    font-family: 'Trade Gothic Condensed Bold';
+    src: url('fonts/tradegothic-boldcondtwenty-webfont.eot');
+    src: url('fonts/tradegothic-boldcondtwenty-webfont.eot?#iefix') format('embedded-opentype'),
+    url('fonts/tradegothic-boldcondtwenty-webfont.woff') format('woff'),
+    url('fonts/tradegothic-boldcondtwenty-webfont.ttf') format('truetype'),
+    url('fonts/tradegothic-boldcondtwenty-webfont.svg#tradegothic-boldcondtwenty-webfont') format('svg');
+    font-weight: normal;
+    font-style: normal;
+}


### PR DESCRIPTION
When looking at the diff in Github it looks like AbstractCssUrlRewritingProcessor is replaced in its entirety.
What is changed is really the regex. The old pattern matched the whole declaration of the css rule. For all cases except FallbackCssDataUriProcessor this was overkill.

In order to support FallbackCssDataUriProcessor AbstractCssUrlRewritingProcessor now has protected methods for getting the regexpattern-key and the index of the necessary groups.
