### PR TITLE
Fix demo with maven 3

### DIFF
--- a/wro4j-examples/wro4j-demo/pom.xml
+++ b/wro4j-examples/wro4j-demo/pom.xml
@@ -16,7 +16,7 @@
 	<properties>
 		<wicket.version>1.5.2</wicket.version>
 		<gae.version>1.5.4</gae.version>
-		<jetty.version>8.0.0.M1</jetty.version>
+		<jetty.version>8.1.8.v20121106</jetty.version>
 		<dwr.version>3.0.M1</dwr.version>
 		<guice.version>3.0</guice.version>
 		<project_charset>UTF-8</project_charset>
@@ -103,7 +103,7 @@
 		<dependency>
 			<groupId>com.google.appengine.orm</groupId>
 			<artifactId>datanucleus-appengine</artifactId>
-			<version>1.0.6</version>
+			<version>1.0.9</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.geronimo.specs</groupId>
@@ -186,6 +186,11 @@
 					</webAppConfig>
 				</configuration>
 			</plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>2.3</version>
+      </plugin>
 		</plugins>
 	</build>
 	<repositories>


### PR DESCRIPTION
- changed version of jetty-maven-plugin as 8.0.0.M1 seems to be a dud with maven 3.
- see http://stackoverflow.com/questions/4154238/jetty-maven-plugin-does-not-work-with-maven-3 for details

I found the above problem using Apache Maven 3.0.3 and java 7 on OSX
Updating to a newer version of the jetty-maven-plugin fixed the problem.
