### PR TITLE
1.6.x fix for HoganJs processor

### DIFF
--- a/wro4j-extensions/src/main/java/ro/isdc/wro/extensions/processor/support/hoganjs/HoganJs.java
+++ b/wro4j-extensions/src/main/java/ro/isdc/wro/extensions/processor/support/hoganjs/HoganJs.java
@@ -20,7 +20,6 @@ public class HoganJs
    */
   @Override
   public String compile(final String content, final String optionalArgument) {
-    return String.format("Hogan.cache['%s'] = %s", optionalArgument, super.compile(content, ""));
     return String.format("Hogan.cache['%s'] = %s;", optionalArgument, super.compile(content, ""));
   }
 


### PR DESCRIPTION
The HoganJs compilation output needs a semicolon when there are multiple templates being compiled.  Otherwise the generated JavaScript is invalid.
