### PR TITLE
Create wro4j-osgi bundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,13 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
           <version>2.2.1</version>
-        </plugin>    
+        </plugin>
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <version>2.3.7</version>
+          <extensions>true</extensions>
+        </plugin>
       </plugins>
     </pluginManagement>  
     <plugins>        
@@ -361,7 +367,8 @@
         <module>wro4j-core</module>          
         <module>wro4j-extensions</module>
         <module>wro4j-maven-plugin</module>
-        <module>wro4j-runner</module>           
+        <module>wro4j-runner</module>
+        <module>wro4j-osgi</module>
       </modules>
     </profile>  
     <profile>
@@ -373,8 +380,9 @@
         <module>wro4j-core</module>          
         <module>wro4j-extensions</module>
         <module>wro4j-maven-plugin</module>
-        <module>wro4j-runner</module>           
-        <module>wro4j-examples</module>        
+        <module>wro4j-runner</module>
+        <module>wro4j-examples</module>
+        <module>wro4j-osgi</module>
       </modules>
     </profile>  
     <profile>
@@ -386,6 +394,7 @@
         <module>wro4j-core</module>          
         <module>wro4j-extensions</module>
         <module>wro4j-maven-plugin</module>
+        <module>wro4j-osgi</module>
       </modules>
     </profile>    
     <profile>
@@ -402,6 +411,7 @@
         <module>wro4j-core</module>    
         <module>wro4j-extensions</module>
         <module>wro4j-maven-plugin</module>
+        <module>wro4j-osgi</module>
       </modules>
 
       <build>      
@@ -440,6 +450,11 @@
             <configuration>
               <updateReleaseInfo>true</updateReleaseInfo>
             </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>maven-bundle-plugin</artifactId>
+            <version>2.3.7</version>
           </plugin>
         </plugins>
       </build>

--- a/wro4j-core/src/main/java/ro/isdc/wro/util/provider/ProviderFinder.java
+++ b/wro4j-core/src/main/java/ro/isdc/wro/util/provider/ProviderFinder.java
@@ -1,9 +1,6 @@
 package ro.isdc.wro.util.provider;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 import javax.imageio.spi.ServiceRegistry;
 
@@ -99,12 +96,21 @@ public class ProviderFinder<T> {
   @SuppressWarnings("unchecked")
   <P> Iterator<P> lookupProviders(final Class<P> providerClass) {
     LOG.debug("searching for providers of type : {}", providerClass);
+
+    ClassLoader orig = Thread.currentThread().getContextClassLoader();
+
     try {
+
+      Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
+
       final Class<?> serviceLoader = getClass().getClassLoader().loadClass("java.util.ServiceLoader");
       LOG.debug("using {} to lookupProviders", serviceLoader.getName());
       return ((Iterable<P>) serviceLoader.getMethod("load", Class.class).invoke(serviceLoader, providerClass)).iterator();
     } catch (final Exception e) {
       LOG.debug("ServiceLoader is not available. Falling back to ServiceRegistry.", e);
+    } finally {
+
+      Thread.currentThread().setContextClassLoader(orig);
     }
     LOG.debug("using {} to lookupProviders", ServiceRegistry.class.getName());
     return ServiceRegistry.lookupProviders(providerClass);

--- a/wro4j-osgi/README.md
+++ b/wro4j-osgi/README.md
@@ -1,0 +1,36 @@
+# Overview
+
+The wro4j library uses
+[spi](http://en.wikipedia.org/wiki/Service_provider_interface) to find
+classes at runtime. There are some issues with using SPI inside osgi.
+This project makes it possible to use wro4j inside osgi by temporarily
+setting the thread context class loader (tccl).  
+
+# Usage
+
+First, create the wro4j-osgi bundle by building this module using
+`mvn install`. 
+
+Then install the bundle into your osgi container. For karaf, we used: 
+
+    install mvn: mvn:ro.isdc.wro4j/wro4j-osgi/1.6.2
+
+All processors inside wro4j-core should work in osgi. 
+
+We also needed a less compiler in osgi. So, this bundle also includes
+the relevant parts from wro4j-extensions in order to use either the
+less4j or the lessCss compiler processor.
+
+To use less4j inside osgi, it's also required to install bundles for
+less4j and anltr to satisfy dependencies. Here's the syntax for karaf:
+
+    install wrap:mvn:org.antlr/antlr-runtime/3.4
+    install wrap:mvn:com.github.sommeri/less4j/1.0.3-SNAPSHOT
+    
+To use lessCss inside osgi, it's also required to install bundles for
+rhinojs and commons-pool. Here's the syntax for karaf: 
+
+    install mvn:commons-pool/commons-pool/1.6
+    install wrap:mvn:org.mozilla/rhino/1.7R1
+
+After that, wro4j core + less compilers will be available inside osgi!

--- a/wro4j-osgi/pom.xml
+++ b/wro4j-osgi/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>ro.isdc.wro4j</groupId>
+    <artifactId>wro4j-parent</artifactId>
+    <version>1.6.2</version>
+  </parent>
+
+  <groupId>ro.isdc.wro4j</groupId>
+  <artifactId>wro4j-osgi</artifactId>
+  <packaging>bundle</packaging>
+  <name>wro4j osgified</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>wro4j-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>wro4j-extensions</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <Import-Package>
+              junit.framework; resolution:=optional,
+              org.slf4j.impl; resolution:=optional,
+              com.github.lltyk.rhino17r1; resolution:=optional,
+              com.google.gson; resolution:=optional,
+              com.google.gson.reflect; resolution:=optional,
+              com.google.javascript.jscomp; resolution:=optional,
+              groovy.lang; resolution:=optional; resolution:=optional,
+              javax.script; resolution:=optional,
+              org.apache.commons.pool; resolution:=optional,
+              org.apache.commons.pool.impl; resolution:=optional,
+              org.codehaus.groovy.reflection; resolution:=optional,
+              org.codehaus.groovy.runtime; resolution:=optional,
+              org.codehaus.groovy.runtime.callsite; resolution:=optional,
+              org.codehaus.groovy.runtime.typehandling; resolution:=optional,
+              org.codehaus.groovy.runtime.wrappers; resolution:=optional,
+              org.dojotoolkit.shrinksafe; resolution:=optional,
+              *
+            </Import-Package>
+            <Export-Package>
+              ro.isdc.wro.*
+            </Export-Package>
+            <_exportcontents />
+            <Embed-Dependency>*;scope=compile;inline=false</Embed-Dependency>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>


### PR DESCRIPTION
This pull request makes it possible to use wro4j servlet filters inside osgi environments. 

The new wro4j-osgi module uses the maven-bundle-plugin to add the required metadata to the manifest in order to create a valid wro4j-osgi bundle jar that can then be used inside osgi. 

A workaround is provided so that SPI calls (such as ServiceLoader.load) will work correctly inside osgi's more restricted classloader rules. This allows wro4j to find providers inside osgi.

This has been tested inside Apache Karaf 4.2. 

As an added bonus for development time, if you use "file:" uris to define groups inside wro.xml configuration, then when js and css files are edited, the changes will show up instantly (no rebuild and/or redeploy into osgi required). 

Please see wro4j-osgi/README.md for more
