### PR TITLE
Have the WRO filters also handle the REQUEST, FORWARD, and ERROR dispatches

### DIFF
--- a/wro4j-grails-plugin/Wro4jGrailsPlugin.groovy
+++ b/wro4j-grails-plugin/Wro4jGrailsPlugin.groovy
@@ -53,12 +53,18 @@ class Wro4jGrailsPlugin {
       'filter-mapping' {
         'filter-name'('wroContextFilter')
         'url-pattern'('/*')
+        'dispatcher'('REQUEST')
+        'dispatcher'('FORWARD')
+        'dispatcher'('ERROR')
       }
     }
     filter[filter.size() - 1] + {
       'filter-mapping' {
         'filter-name'('wroFilter')
         'url-pattern'('/wro/*')
+        'dispatcher'('REQUEST')
+        'dispatcher'('FORWARD')
+        'dispatcher'('ERROR')
       }
     }
   }


### PR DESCRIPTION
By default, servlet filters only handle REQUEST. Which means that if an ERROR is handled, the filters don't execute. So in this case, if WRO is used during the processing of the ERROR request, the context won't be set (because the wroContextFilter didn't execute) resulting in a context not set exception.
