### PR TITLE
add SERVLET_CONTEXT_ONLY LocatorStrategy

### DIFF
--- a/wro4j-core/src/main/java/ro/isdc/wro/model/resource/locator/ServletContextUriLocator.java
+++ b/wro4j-core/src/main/java/ro/isdc/wro/model/resource/locator/ServletContextUriLocator.java
@@ -71,9 +71,10 @@ public class ServletContextUriLocator
    * use the ServletContext to locate the resource. SERVLET_CONTEXT_FIRST is a alternative approach where we will first
    * try to locate the resource VIA the ServletContext first, and then use the dispatcheStreamLocator if not found. In
    * some cases, where you do not rely on dynamic resources this can be a more reliable and a more efficient approach.
+   * If requests should never be forwarded to a servlet, use SERVLET_CONTEXT_ONLY.
    */
   public static enum LocatorStrategy {
-    DISPATCHER_FIRST, SERVLET_CONTEXT_FIRST
+    DISPATCHER_FIRST, SERVLET_CONTEXT_FIRST, SERVLET_CONTEXT_ONLY
   }
 
   /**
@@ -155,10 +156,16 @@ public class ServletContextUriLocator
 
     InputStream inputStream = null;
     try {
-      if (locatorStrategy.equals(LocatorStrategy.DISPATCHER_FIRST)) {
-        inputStream = dispatcherFirstStreamLocator(uri);
-      } else {
-        inputStream = servletContextFirstStreamLocator(uri);
+      switch (locatorStrategy) {
+        case DISPATCHER_FIRST:
+          inputStream = dispatcherFirstStreamLocator(uri);
+          break;
+        case SERVLET_CONTEXT_FIRST:
+          inputStream = servletContextFirstStreamLocator(uri);
+          break;
+        case SERVLET_CONTEXT_ONLY:
+          inputStream = servletContextBasedStreamLocator(uri);
+          break;
       }
       validateInputStreamIsNotNull(inputStream, uri);
       return inputStream;


### PR DESCRIPTION
We use wro4j-maven-plugin in production, and WroFilter in development. The maven plugin can't load dynamic resources, so I'd like to the filter not to load them either.

When using `SERVLET_CONTEXT_FIRST`, missing resources show up as 404s in unrelated subsystems (wherever the request gets dispatched to).
