### PR TITLE
Port JSMin fix to handle slash inside square brackets in regex.

### DIFF
--- a/wro4j-core/src/main/java/ro/isdc/wro/model/resource/processor/support/JSMin.java
+++ b/wro4j-core/src/main/java/ro/isdc/wro/model/resource/processor/support/JSMin.java
@@ -114,10 +114,14 @@ public class JSMin {
   }
 
   /**
-   * action -- do something! What you do is determined by the argument: 1 Output
-   * A. Copy B to A. Get the next B. 2 Copy B to A. Get the next B. (Delete A).
-   * 3 Get the next B. (Delete B). action treats a string as a single character.
-   * Wow! action recognizes a regular expression if it is preceded by ( or , or =.
+   * action -- do something! What you do is determined by the argument:
+   * <ul>
+   *   <li>1 Output A. Copy B to A. Get the next B.</li>
+   *   <li>2 Copy B to A. Get the next B. (Delete A).</li>
+   *   <li>3 Get the next B. (Delete B).</li>
+   * </ul>
+   * action treats a string as a single character. Wow!<br/>
+   * action recognizes a regular expression if it is preceded by ( or , or =.
    */
 
   void action(final int d) throws IOException,
@@ -156,7 +160,22 @@ public class JSMin {
         out.write(theB);
         for (;;) {
           theA = get();
-          if (theA == '/') {
+          if (theA == '[') {
+            for (;;) {
+              out.write(theA);
+              theA = get();
+              if (theA == ']') {
+                break;
+              }
+              if (theA == '\\') {
+                out.write(theA);
+                theA = get();
+              }
+              if (theA <= '\n') {
+                throw new UnterminatedRegExpLiteralException();
+              }
+            }
+          } else if (theA == '/') {
             break;
           } else if (theA == '\\') {
             out.write(theA);

--- a/wro4j-core/src/test/java/ro/isdc/wro/model/resource/processor/support/JSMinTest.java
+++ b/wro4j-core/src/test/java/ro/isdc/wro/model/resource/processor/support/JSMinTest.java
@@ -1,0 +1,25 @@
+package ro.isdc.wro.model.resource.processor.support;
+
+import org.apache.commons.io.input.ReaderInputStream;
+import org.apache.commons.io.output.WriterOutputStream;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.*;
+
+public class JSMinTest {
+    @Test
+    public void shouldHandleSlashAndIsolatedSingleQuoteInRegexes() throws Exception {
+        String script = "var slashOrDoubleQuote=/[/']/g;";
+        Assert.assertEquals("\n" + script, jsmin(script));
+    }
+
+    private String jsmin(String inputScript) throws Exception {
+        StringReader reader = new StringReader(inputScript);
+        InputStream is = new ReaderInputStream(reader, "UTF-8");
+        StringWriter writer = new StringWriter();
+        OutputStream os = new WriterOutputStream(writer, "UTF-8");
+        new JSMin(is, os).jsmin();
+        return writer.toString();
+    }
+}


### PR DESCRIPTION
The JSMin bundled in Wro4J fails on regexes like `/[/']/`. The second `/` is mistakenly intepreted as the end of the regex.

This bug was fixed on the original C implementation (douglascrockford/JSMin@55809e6d07be4a0d3029d48112d16ef833e55cf7); this is a simple port of the changes.

I ran into the bug while trying to minify [chjj/marked](https://github.com/chjj/marked).
