### PR TITLE
Issue660: port remaining JSMin fixes

### DIFF
--- a/wro4j-core/src/main/java/ro/isdc/wro/model/resource/processor/support/JSMin.java
+++ b/wro4j-core/src/main/java/ro/isdc/wro/model/resource/processor/support/JSMin.java
@@ -187,6 +187,11 @@ public class JSMin {
               }
             }
           } else if (theA == '/') {
+            switch (peek()) {
+            case '/':
+            case '*':
+              throw new UnterminatedRegExpLiteralException();
+            }
             break;
           } else if (theA == '\\') {
             out.write(theA);

--- a/wro4j-core/src/test/java/ro/isdc/wro/model/resource/processor/TestJsMinProcessor.java
+++ b/wro4j-core/src/test/java/ro/isdc/wro/model/resource/processor/TestJsMinProcessor.java
@@ -160,6 +160,19 @@ public class TestJsMinProcessor {
         jsmin("return /a;/.test(s);"));
   }
 
+  @Test(expected = Exception.class)
+  public void shouldFailOnInlineCommentAfterUnclosedRegexp() throws Exception {
+    // Make this fail to be consistent with the original JSMin, although this is in fact valid Javascript if comment is
+    // a defined variable.
+    jsmin("var r = /a //comment");
+  }
+
+  @Test(expected = Exception.class)
+  public void shouldFailOnUnclosedBlockCommentAfterUnclosedRegexp() throws Exception {
+    // same comment as above
+    jsmin("var r = /a/*comment");
+  }
+
   private String jsmin(final String inputScript) throws Exception {
       final StringReader reader = new StringReader(inputScript);
       final InputStream is = new ReaderInputStream(reader, "UTF-8");


### PR DESCRIPTION
Hi,

I've finally found some time to finish #151 (sorry for the delay, holidays got in the way).

I've organized the history a bit differently (some fixes didn't compile in Java because of unreachable code, and were fixed in subsequent commits!). I've added links in the logs to make it clear what comes from where.

The hardest part was to find out what each commit did and write a unit test for it (some are weird corner cases).  Your example from last time now works.
