### PR TITLE
Allow wro4j-maven-plugin callers to skip execution

### DIFF
--- a/wro4j-maven-plugin/src/main/java/ro/isdc/wro/maven/plugin/AbstractWro4jMojo.java
+++ b/wro4j-maven-plugin/src/main/java/ro/isdc/wro/maven/plugin/AbstractWro4jMojo.java
@@ -52,6 +52,13 @@ public abstract class AbstractWro4jMojo
    */
   private File wroFile;
   /**
+   * Whether to skip executing Wro4j. Allows clients to pass a build-time parameter to skip running wro4j.
+   *
+   * @parameter default-value=false
+   * @optional
+   */
+   private boolean skip;
+  /**
    * The folder where web application context resides useful for locating resources relative to servletContext. It is
    * possible to provide multiple context folders using a CSV. When multiple contextFolders are provided, the
    * servletContext locator will try to search in next contextFolder when a resource could not be located. By default, a
@@ -139,6 +146,10 @@ public abstract class AbstractWro4jMojo
   public final void execute()
       throws MojoExecutionException {
     validate();
+    if (skip) {
+      getLog().info("Skipping Wro4j execution");
+      return;
+    }
     getLog().info(contextFolder);
     getLog().info("Executing the mojo: ");
     getLog().info("Wro4j Model path: " + wroFile.getPath());


### PR DESCRIPTION
Adds a property to wro4j-maven-plugin to allow skipping execution.
If 'skip' is set to true, Wro4j does not run. This allows users
to skip Wro4j based on a command-line maven option eg for
development.
