### PR TITLE
Use this.wroModel instead of wroModel

### DIFF
--- a/wro4j-extensions/src/main/groovy/ro/isdc/wro/extensions/model/factory/GroovyModelParser.groovy
+++ b/wro4j-extensions/src/main/groovy/ro/isdc/wro/extensions/model/factory/GroovyModelParser.groovy
@@ -58,7 +58,7 @@ class WroModelDelegate {
     def groupDelegate = new GroupDelegate()
     cl.delegate = groupDelegate
     cl()
-    wroModel = new WroModel(groups: (Collection<Group>) cl.resolveGroupResources())
+    this.wroModel = new WroModel(groups: (Collection<Group>) cl.resolveGroupResources())
   }
 
 }


### PR DESCRIPTION
wroModel creates a new variable, but this.wroModel sets the existing property. This change fixes a bug in loading the wroModel.
