### PR TITLE
Fix RubySass compile error for non-ascii characters

### DIFF
--- a/wro4j-extensions/src/main/java/ro/isdc/wro/extensions/processor/support/sass/RubySassEngine.java
+++ b/wro4j-extensions/src/main/java/ro/isdc/wro/extensions/processor/support/sass/RubySassEngine.java
@@ -33,6 +33,7 @@ public class RubySassEngine {
   private final Set<String> requires;
 
   public RubySassEngine() {
+    System.setProperty("org.jruby.embed.compat.version", "JRuby1.9");
     requires = new LinkedHashSet<String>();
     requires.add(RUBY_GEM_REQUIRE);
     requires.add(SASS_PLUGIN_REQUIRE);
@@ -75,13 +76,32 @@ public class RubySassEngine {
     final StringWriter raw = new StringWriter();
     final PrintWriter script = new PrintWriter(raw);
     final StringBuilder sb = new StringBuilder();
+    final StringBuilder cb = new StringBuilder();
     sb.append(":syntax => :scss");
 
     for (final String require : requires) {
       script.println("  require '" + require + "'                                   ");
     }
-    final String scriptAsString = String.format("result = Sass::Engine.new('%s', {%s}).render",
-        content.replace("'", "\""),
+    final int BACKSLASH = 0x5c;
+    for (int i = 0; i < content.length(); i++) {
+      final int code = content.codePointAt(i);
+      if (code < 0x80) {
+        // We leave only ASCII unchanged.
+        if (code == BACKSLASH) {
+          // escape backslash
+          cb.append("\\");
+        }
+        cb.append(content.charAt(i));
+      } else {
+        // Non-ASCII String may cause invalid multibyte char (US-ASCII) error with Ruby 1.9
+        // because Ruby 1.9 expects you to use ASCII characters in your source code.
+        // Instead we use Unicode code point representation which is usable with
+        // Ruby 1.9 and later.
+        cb.append(String.format("\\u%04x", code));
+      }
+    }
+    final String scriptAsString = String.format("result = Sass::Engine.new(\"%s\", {%s}).render",
+        cb.toString().replace("\"", "\\\"").replace("#", "\\#"), // escape ", #
         sb.toString());
     LOG.debug("scriptAsString: {}", scriptAsString);
     script.println(scriptAsString);

--- a/wro4j-extensions/src/test/java/ro/isdc/wro/extensions/processor/support/sass/TestRubySassEngine.java
+++ b/wro4j-extensions/src/test/java/ro/isdc/wro/extensions/processor/support/sass/TestRubySassEngine.java
@@ -53,4 +53,11 @@ public class TestRubySassEngine {
     throws IOException {
     assertEquals("#element #child {\n  color: red; }\n", engine.process("#element { #child {color: red;}}"));
   }
+
+  @Test
+  public void shouldProcessValidNonAsciiSass()
+    throws IOException {
+    assertEquals("@charset \"UTF-8\";\n#element {\n  font-family: \"\uFF2D\uFF33 \uFF30\u30B4\u30B7\u30C3\u30AF\"; }\n",
+        engine.process("#element {font-family: \"\uFF2D\uFF33 \uFF30\u30B4\u30B7\u30C3\u30AF\";}"));
+  }
 }


### PR DESCRIPTION
If a sass file contains non-ascii characters, sass compiling fails
with invalid multibyte char (US-ASCII) error on Windows 7 with
JRuby 1.7.x.

JRuby 1.7.x works with Ruby 1.9 mode by default.
We convert string to Unicode code point representaion to fix
compile error.

We set org.jruby.embed.compat.version 1.9 for JRuby 1.6.x.
