### PR TITLE
Fix property in Mojo Javadoc tag

### DIFF
--- a/wro4j-maven-plugin/src/main/java/ro/isdc/wro/maven/plugin/AbstractLinterMojo.java
+++ b/wro4j-maven-plugin/src/main/java/ro/isdc/wro/maven/plugin/AbstractLinterMojo.java
@@ -37,7 +37,7 @@ public abstract class AbstractLinterMojo<T>
   /**
    * When true, all the plugin won't stop its execution and will log all found errors.
    *
-   * @parameter default-value="false" property="${failNever}"
+   * @parameter default-value="false" property="failNever"
    * @optional
    */
   private boolean failNever;
@@ -45,14 +45,14 @@ public abstract class AbstractLinterMojo<T>
    * Allows build to fail when the first error is encountered without searching for next errors. This flag is true by
    * default. When interested in all errors, set this flag to false.
    *
-   * @parameter default-value="true" property="${failFast}"
+   * @parameter default-value="true" property="failFast"
    * @optional
    */
   private boolean failFast = true;
   /**
    * Counts maximum acceptable number of jshint errors, useful for progressive code quality enhancement strategy.
    *
-   * @parameter property="${failThreshold}"
+   * @parameter property="failThreshold"
    * @optional
    */
   private int failThreshold = 0;

--- a/wro4j-maven-plugin/src/main/java/ro/isdc/wro/maven/plugin/AbstractSingleProcessorMojo.java
+++ b/wro4j-maven-plugin/src/main/java/ro/isdc/wro/maven/plugin/AbstractSingleProcessorMojo.java
@@ -36,14 +36,14 @@ public abstract class AbstractSingleProcessorMojo
   /**
    * Comma separated options. This field is optional. If no value is provided, no options will be used..
    *
-   * @parameter property="${options}"
+   * @parameter property="options"
    * @optional
    */
   private String options;
   /**
    * When true, all the plugin won't stop its execution and will log all found errors.
    *
-   * @parameter default-value="false" property="${failNever}"
+   * @parameter default-value="false" property="failNever"
    * @optional
    */
   private boolean failNever;

--- a/wro4j-maven-plugin/src/main/java/ro/isdc/wro/maven/plugin/AbstractWro4jMojo.java
+++ b/wro4j-maven-plugin/src/main/java/ro/isdc/wro/maven/plugin/AbstractWro4jMojo.java
@@ -47,7 +47,7 @@ public abstract class AbstractWro4jMojo
   /**
    * File containing the groups definitions.
    *
-   * @parameter default-value="${basedir}/src/main/webapp/WEB-INF/wro.xml" property="${wroFile}"
+   * @parameter default-value="${basedir}/src/main/webapp/WEB-INF/wro.xml" property="wroFile"
    * @optional
    */
   private File wroFile;
@@ -64,17 +64,17 @@ public abstract class AbstractWro4jMojo
    * servletContext locator will try to search in next contextFolder when a resource could not be located. By default, a
    * single context folder is configured.
    *
-   * @parameter default-value="${basedir}/src/main/webapp/" property="${contextFolder}"
+   * @parameter default-value="${basedir}/src/main/webapp/" property="contextFolder"
    * @optional
    */
   private String contextFolder;
   /**
-   * @parameter default-value="true" property="${minimize}"
+   * @parameter default-value="true" property="minimize"
    * @optional
    */
   private boolean minimize;
   /**
-   * @parameter property="${ignoreMissingResources}"
+   * @parameter property="ignoreMissingResources"
    * @optional
    */
   private String ignoreMissingResources;
@@ -82,7 +82,7 @@ public abstract class AbstractWro4jMojo
    * Comma separated group names. This field is optional. If no value is provided, a file for each group will be
    * created.
    *
-   * @parameter property="${targetGroups}"
+   * @parameter property="targetGroups"
    * @optional
    */
   private String targetGroups;
@@ -91,7 +91,7 @@ public abstract class AbstractWro4jMojo
    */
   private MavenProject mavenProject;
   /**
-   * @parameter property="${wroManagerFactory}"
+   * @parameter property="wroManagerFactory"
    * @optional
    */
   private String wroManagerFactory;
@@ -102,7 +102,7 @@ public abstract class AbstractWro4jMojo
   /**
    * The path to configuration file.
    *
-   * @parameter default-value="${basedir}/src/main/webapp/WEB-INF/wro.properties" property="${extraConfigFile}"
+   * @parameter default-value="${basedir}/src/main/webapp/WEB-INF/wro.properties" property="extraConfigFile"
    * @optional
    */
   private File extraConfigFile;
@@ -125,7 +125,7 @@ public abstract class AbstractWro4jMojo
    * When this flag is enabled and there are more than one group to be processed, these will be processed in parallel,
    * resulting in faster overall plugin execution time.
    *
-   * @parameter default-value="false" property="${parallelProcessing}"
+   * @parameter default-value="false" property="parallelProcessing"
    * @optional
    */
   private boolean parallelProcessing;
@@ -133,7 +133,7 @@ public abstract class AbstractWro4jMojo
    * Flag which allows to enable incremental build (experimental feature). It is false by default, but probably can be
    * changed to true if no unexpected problems are detected..
    *
-   * @parameter default-value="false" property="${incrementalBuildEnabled}"
+   * @parameter default-value="false" property="incrementalBuildEnabled"
    * @optional
    */
   private boolean incrementalBuildEnabled;

--- a/wro4j-maven-plugin/src/main/java/ro/isdc/wro/maven/plugin/CssLintMojo.java
+++ b/wro4j-maven-plugin/src/main/java/ro/isdc/wro/maven/plugin/CssLintMojo.java
@@ -37,14 +37,14 @@ public class CssLintMojo
   /**
    * File where the report will be written.
    *
-   * @parameter default-value="${project.build.directory}/wro4j-reports/csslint.xml" property="${reportFile}"
+   * @parameter default-value="${project.build.directory}/wro4j-reports/csslint.xml" property="reportFile"
    * @optional
    */
   private File reportFile;
   /**
    * The preferred format of the report.
    *
-   * @parameter property="${reportFormat}"
+   * @parameter property="reportFormat"
    * @optional
    */
   private String reportFormat = FormatterType.LINT.getFormat();

--- a/wro4j-maven-plugin/src/main/java/ro/isdc/wro/maven/plugin/JsHintMojo.java
+++ b/wro4j-maven-plugin/src/main/java/ro/isdc/wro/maven/plugin/JsHintMojo.java
@@ -36,14 +36,14 @@ public class JsHintMojo
   /**
    * File where the report will be written.
    *
-   * @parameter default-value="${project.build.directory}/wro4j-reports/jshint.xml" property="${reportFile}"
+   * @parameter default-value="${project.build.directory}/wro4j-reports/jshint.xml" property="reportFile"
    * @optional
    */
   private File reportFile;
   /**
    * The preferred format of the report.
    *
-   * @parameter property="${reportFormat}"
+   * @parameter property="reportFormat"
    * @optional
    */
   private String reportFormat = FormatterType.JSLINT.getFormat();

--- a/wro4j-maven-plugin/src/main/java/ro/isdc/wro/maven/plugin/JsLintMojo.java
+++ b/wro4j-maven-plugin/src/main/java/ro/isdc/wro/maven/plugin/JsLintMojo.java
@@ -37,14 +37,14 @@ public class JsLintMojo
   /**
    * File where the report will be written.
    *
-   * @parameter default-value="${project.build.directory}/wro4j-reports/jslint.xml" property="${reportFile}"
+   * @parameter default-value="${project.build.directory}/wro4j-reports/jslint.xml" property="reportFile"
    * @optional
    */
   private File reportFile;
   /**
    * The preferred format of the report.
    *
-   * @parameter property="${reportFormat}"
+   * @parameter property="reportFormat"
    * @optional
    */
   private String reportFormat = FormatterType.JSLINT.getFormat();

--- a/wro4j-maven-plugin/src/main/java/ro/isdc/wro/maven/plugin/Wro4jMojo.java
+++ b/wro4j-maven-plugin/src/main/java/ro/isdc/wro/maven/plugin/Wro4jMojo.java
@@ -48,17 +48,17 @@ public class Wro4jMojo
   /**
    * The path to the destination directory where the files are stored at the end of the process.
    *
-   * @parameter default-value="${project.build.directory}" property="${destinationFolder}"
+   * @parameter default-value="${project.build.directory}" property="destinationFolder"
    * @optional
    */
   private File destinationFolder;
   /**
-   * @parameter property="${cssDestinationFolder}"
+   * @parameter property="cssDestinationFolder"
    * @optional
    */
   private File cssDestinationFolder;
   /**
-   * @parameter property="${jsDestinationFolder}"
+   * @parameter property="jsDestinationFolder"
    * @optional
    */
   private File jsDestinationFolder;
@@ -77,7 +77,7 @@ public class Wro4jMojo
    */
   private File buildFinalName;
   /**
-   * @parameter property="${groupNameMappingFile}"
+   * @parameter property="groupNameMappingFile"
    * @optional
    */
   private File groupNameMappingFile;


### PR DESCRIPTION
${aSystemProperty} doesn't work with property attribute.

https://maven.apache.org/developers/mojo-api-specification.html

```
maven-plugin-plugin 2.x:
@parameter expression="${aSystemProperty}" default-value="${anExpression}"

maven-plugin-plugin 3.x:
@parameter property="aSystemProperty" default-value="${anExpression}"
```

Fix issue 860:
https://code.google.com/p/wro4j/issues/detail?id=860
