### PR TITLE
Fix file descriptor leak

### DIFF
--- a/wro4j-core/src/main/java/ro/isdc/wro/model/resource/support/change/ResourceChangeDetector.java
+++ b/wro4j-core/src/main/java/ro/isdc/wro/model/resource/support/change/ResourceChangeDetector.java
@@ -4,8 +4,11 @@ package ro.isdc.wro.model.resource.support.change;
 import static org.apache.commons.lang3.Validate.notNull;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.commons.io.IOUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,8 +71,13 @@ public class ResourceChangeDetector {
     LOG.debug("group={}, uri={}", groupName, uri);
     final ResourceChangeInfo resourceInfo = changeInfoMap.get(uri);
     if (resourceInfo.isCheckRequiredForGroup(groupName)) {
-      final String currentHash = hashStrategy.getHash(locatorFactory.locate(uri));
-      resourceInfo.updateHashForGroup(currentHash, groupName);
+      final InputStream inputStream = locatorFactory.locate(uri);
+      try{
+        final String currentHash = hashStrategy.getHash(inputStream);
+        resourceInfo.updateHashForGroup(currentHash, groupName);
+      }finally{
+        IOUtils.closeQuietly(inputStream);
+      }
     }
     return resourceInfo.isChanged(groupName);
   }

--- a/wro4j-core/src/main/java/ro/isdc/wro/model/resource/support/hash/AbstractDigesterHashStrategy.java
+++ b/wro4j-core/src/main/java/ro/isdc/wro/model/resource/support/hash/AbstractDigesterHashStrategy.java
@@ -10,6 +10,8 @@ import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
+import org.apache.commons.io.IOUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,6 +46,8 @@ public abstract class AbstractDigesterHashStrategy
       return hash;
     } catch (final NoSuchAlgorithmException e) {
       throw new WroRuntimeException("Exception occured while computing SHA1 hash", e);
+    }finally{
+      IOUtils.closeQuietly(input);
     }
   }
 

--- a/wro4j-core/src/main/java/ro/isdc/wro/model/resource/support/hash/CRC32HashStrategy.java
+++ b/wro4j-core/src/main/java/ro/isdc/wro/model/resource/support/hash/CRC32HashStrategy.java
@@ -6,6 +6,8 @@ import java.math.BigInteger;
 import java.util.zip.CRC32;
 import java.util.zip.Checksum;
 
+import org.apache.commons.io.IOUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,16 +33,20 @@ public class CRC32HashStrategy
     if (input == null) {
       throw new IllegalArgumentException("Content cannot be null!");
     }
-    LOG.debug("creating hash using CRC32 algorithm");
-    final Checksum checksum = new CRC32();
-    final byte[] bytes = new byte[1024];
-    int len = 0;
-    while ((len = input.read(bytes)) >= 0) {
-      checksum.update(bytes, 0, len);
-    }
+    try{
+      LOG.debug("creating hash using CRC32 algorithm");
+      final Checksum checksum = new CRC32();
+      final byte[] bytes = new byte[1024];
+      int len = 0;
+      while ((len = input.read(bytes)) >= 0) {
+        checksum.update(bytes, 0, len);
+      }
 
-    final String hash = new BigInteger(Long.toString(checksum.getValue())).toString(16);
-    LOG.debug("CRC32 hash: {}", hash);
-    return hash;
+      final String hash = new BigInteger(Long.toString(checksum.getValue())).toString(16);
+      LOG.debug("CRC32 hash: {}", hash);
+      return hash;
+    }finally{
+      IOUtils.closeQuietly(input);
+    }
   }
 }

--- a/wro4j-core/src/main/java/ro/isdc/wro/model/resource/support/hash/ConfigurableHashStrategy.java
+++ b/wro4j-core/src/main/java/ro/isdc/wro/model/resource/support/hash/ConfigurableHashStrategy.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 
+import org.apache.commons.io.IOUtils;
+
 import ro.isdc.wro.model.resource.support.AbstractConfigurableSingleStrategy;
 
 
@@ -27,7 +29,11 @@ public class ConfigurableHashStrategy
    */
   public String getHash(final InputStream inputStream)
       throws IOException {
-    return getConfiguredStrategy().getHash(inputStream);
+    try{
+      return getConfiguredStrategy().getHash(inputStream);
+	}finally{
+      IOUtils.closeQuietly(inputStream);
+	}
   }
 
   /**

--- a/wro4j-core/src/main/java/ro/isdc/wro/model/resource/support/naming/DefaultHashEncoderNamingStrategy.java
+++ b/wro4j-core/src/main/java/ro/isdc/wro/model/resource/support/naming/DefaultHashEncoderNamingStrategy.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import ro.isdc.wro.model.group.Inject;
@@ -41,14 +42,18 @@ public class DefaultHashEncoderNamingStrategy
     throws IOException {
     notNull(originalName);
     notNull(inputStream);
-    final String baseName = FilenameUtils.getBaseName(originalName);
-    final String path = FilenameUtils.getPath(originalName);
-    final String extension = FilenameUtils.getExtension(originalName);
-    final String hash = getHashStrategy().getHash(inputStream);
-    final StringBuilder sb = new StringBuilder(path).append(baseName).append("-").append(hash);
-    if (!StringUtils.isEmpty(extension)) {
-      sb.append(".").append(extension);
+    try{
+      final String baseName = FilenameUtils.getBaseName(originalName);
+      final String path = FilenameUtils.getPath(originalName);
+      final String extension = FilenameUtils.getExtension(originalName);
+      final String hash = getHashStrategy().getHash(inputStream);
+      final StringBuilder sb = new StringBuilder(path).append(baseName).append("-").append(hash);
+      if (!StringUtils.isEmpty(extension)) {
+        sb.append(".").append(extension);
+      }
+      return sb.toString();
+    }finally{
+      IOUtils.closeQuietly(inputStream);
     }
-    return sb.toString();
   }
 }

--- a/wro4j-core/src/main/java/ro/isdc/wro/model/resource/support/naming/FolderHashEncoderNamingStrategy.java
+++ b/wro4j-core/src/main/java/ro/isdc/wro/model/resource/support/naming/FolderHashEncoderNamingStrategy.java
@@ -8,6 +8,8 @@ import static org.apache.commons.lang3.Validate.notNull;
 import java.io.IOException;
 import java.io.InputStream;
 
+import org.apache.commons.io.IOUtils;
+
 import ro.isdc.wro.model.group.Inject;
 import ro.isdc.wro.model.resource.support.hash.HashStrategy;
 
@@ -40,8 +42,12 @@ public class FolderHashEncoderNamingStrategy
     throws IOException {
     notNull(originalName);
     notNull(inputStream);
-    final String hash = getHashStrategy().getHash(inputStream);
-    final StringBuilder sb = new StringBuilder(hash).append("/").append(originalName);
-    return sb.toString();
+    try{
+      final String hash = getHashStrategy().getHash(inputStream);
+      final StringBuilder sb = new StringBuilder(hash).append("/").append(originalName);
+      return sb.toString();
+    }finally{
+      IOUtils.closeQuietly(inputStream);
+    }
   }
 }


### PR DESCRIPTION
I haven't tried to use this yet, but it should, in theory, fix the file descriptor leak reported at https://code.google.com/p/wro4j/issues/detail?id=864 Since you're much more familiar with the code, could you also do a review for possible leaking descriptors?

I'm hoping you can publish a snapshot version of 1.7.5 with this fix :-)
