### PR TITLE
Optimize hashing

### DIFF
--- a/wro4j-core/src/main/java/ro/isdc/wro/model/resource/support/hash/AbstractDigesterHashStrategy.java
+++ b/wro4j-core/src/main/java/ro/isdc/wro/model/resource/support/hash/AbstractDigesterHashStrategy.java
@@ -33,8 +33,8 @@ public abstract class AbstractDigesterHashStrategy
     }
     try {
       final MessageDigest messageDigest = newMessageDigest();
-      final byte[] digestArray = messageDigest.digest(IOUtils.toByteArray(input));
-      final String hash = new BigInteger(1, digestArray).toString(16);
+      final byte[] digest = messageDigest.digest(IOUtils.toByteArray(input));
+      final String hash = new BigInteger(1, digest).toString(16);
 
       LOG.debug("{} hash: {}", getClass().getSimpleName(), hash);
       return hash;


### PR DESCRIPTION
By using the method IOUtils.toByteArray() instead of this while loop

```
      while (digestIs.read() != -1) {
      }
```

I got the processing time on my webapp down by 17% (from 2m45s to 2m17s).
