### PR TITLE
Persist fallbackStorage once at the very end

### DIFF
--- a/wro4j-maven-plugin/src/main/java/ro/isdc/wro/maven/plugin/AbstractWro4jMojo.java
+++ b/wro4j-maven-plugin/src/main/java/ro/isdc/wro/maven/plugin/AbstractWro4jMojo.java
@@ -431,7 +431,7 @@ public abstract class AbstractWro4jMojo
    * Invoked right after execution completion. This method is invoked also if the execution failed with an exception.
    */
   protected void onAfterExecute() {
-	  resourceChangeHandler.persist();
+    resourceChangeHandler.persist();
   }
 
   /**

--- a/wro4j-maven-plugin/src/main/java/ro/isdc/wro/maven/plugin/support/BuildContextHolder.java
+++ b/wro4j-maven-plugin/src/main/java/ro/isdc/wro/maven/plugin/support/BuildContextHolder.java
@@ -64,9 +64,8 @@ public class BuildContextHolder {
   }
 
   private void initFallbackStorage() throws IOException {
-	fallbackStorage = new Properties();
-	  
-	File rootFolder = new File(buildDirectory, ROOT_FOLDER_NAME);
+    fallbackStorage = new Properties();
+    File rootFolder = new File(buildDirectory, ROOT_FOLDER_NAME);
     fallbackStorageFile = new File(rootFolder, FALLBACK_STORAGE_FILE_NAME);
     if (!fallbackStorageFile.exists()) {
       fallbackStorageFile.getParentFile().mkdirs();

--- a/wro4j-maven-plugin/src/main/java/ro/isdc/wro/maven/plugin/support/ResourceChangeHandler.java
+++ b/wro4j-maven-plugin/src/main/java/ro/isdc/wro/maven/plugin/support/ResourceChangeHandler.java
@@ -267,6 +267,6 @@ public class ResourceChangeHandler {
    * Persist the values stored in BuildContext(Holder)
    */
   public void persist() {
-	  getBuildContextHolder().persist();
+    getBuildContextHolder().persist();
   }
 }


### PR DESCRIPTION
Instead of persisting the fallbackStorage after every value set it is now saved once at the very end of the plugin's execution.
