### PR TITLE
Optimize how often files are checksummed

### DIFF
--- a/wro4j-maven-plugin/src/main/java/ro/isdc/wro/maven/plugin/support/BuildContextHolder.java
+++ b/wro4j-maven-plugin/src/main/java/ro/isdc/wro/maven/plugin/support/BuildContextHolder.java
@@ -5,7 +5,9 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.HashSet;
 import java.util.Properties;
+import java.util.Set;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -36,6 +38,7 @@ public class BuildContextHolder {
   private Properties fallbackStorage;
   private File fallbackStorageFile;
   private boolean incrementalBuildEnabled;
+  private Set<String> isAddesInThisRun = new HashSet<String>();
 
   /**
    * @return an instance of {@link BuildContextHolder} which uses temp folder as root location of persisted data.
@@ -119,6 +122,7 @@ public class BuildContextHolder {
   public void setValue(final String key, final String value) {
     LOG.debug("storing key: '{}' and value: '{}'", key, value);
     if (key != null) {
+      isAddesInThisRun.add(key);
       if (buildContext != null) {
         buildContext.setValue(key, value);
       }
@@ -168,5 +172,9 @@ public class BuildContextHolder {
     } finally {
       IOUtils.closeQuietly(os);
     }
+  }
+
+  public boolean isAddesInThisRun(String key) {
+	return isAddesInThisRun.contains(key);
   }
 }


### PR DESCRIPTION
In #189 we already discussed that persistingFingerprint was taking more time than it should. I looked into this and found that files that are included by many different files get fingerprinted every time.
The problem is that you can't just ask the BuildContextHolder if it has a value for the key (URI of the resource) because it would return the value for this key stored in a former build.

So I added a set to BuildContextHolder that stores if the key was set in the current run. This set is not persisted so it only contains keys that are recently set. ResourceChangeHandler then asks the BuildContextHolder if the value (checksum) for the key (URI of the resource that should be fingerprinted) has already been calculated in this run. If this is true it just skips the costly fingerprinting of said resource.

This way we save a lot of time in incrementalBuilds. We got our building time down 84% to 2s from 13s without the optimization.

I'm not quite happy with the wording though. So this is more a prove of concept that works remarkably well with our setup. Yes, we have a **lot** of includes and cascaded files. :)
